### PR TITLE
New layouts

### DIFF
--- a/usr/share/onboard/layouts/Grid-ko.onboard
+++ b/usr/share/onboard/layouts/Grid-ko.onboard
@@ -1,0 +1,116 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+
+<!--
+Copyright © 2012-2015 marmuta <marmvta@gmail.com>
+
+This file is part of Onboard.
+
+Onboard is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+Onboard is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<keyboard 
+    id='Korean Keyboard Grid'
+    format='3.2'
+    section="system"
+    summary="Grid of keys, suitable for keyboard scanning" >
+
+    <include file='key_defs.xml'/>
+
+    <box border="0.5" spacing="1.5" orientation="vertical">
+        <!--- word suggestions -->
+        <panel filename='Grid-Alpha.svg'>
+            <include file='word_suggestions.xml'/>
+        </panel>
+
+        <box spacing="1.5">
+            <panel layer='alpha' filename='Grid-Alpha.svg'>
+                <key group='alphanumeric' id='0' keycode='19'/>
+                <key group='alphanumeric' id='1' keycode='10'/>
+                <key group='alphanumeric' id='2' keycode='11'/>
+                <key group='alphanumeric' id='3' keycode='12'/>
+                <key group='alphanumeric' id='4' keycode='13'/>
+                <key group='alphanumeric' id='5' keycode='14'/>
+                <key group='alphanumeric' id='6' keycode='15'/>
+                <key group='alphanumeric' id='7' keycode='16'/>
+                <key group='alphanumeric' id='8' keycode='17'/>
+                <key group='alphanumeric' id='9' keycode='18'/>
+                <key group='alphanumeric' id='e' keycode='26' label="e ㄷ" shift_label="E ㄸ" sticky="false"/>
+                <key group='alphanumeric' id='r' keycode='27' label="r ㄱ" shift_label="R ㄲ" sticky="false"/>
+                <key group='alphanumeric' id='t' keycode='28' label="t ㅅ" shift_label="T ㅆ" sticky="false"/>
+                <key group='alphanumeric' id='y' keycode='29' label="y ㅛ" shift_label="Y ㅛ" sticky="false"/>
+                <key group='alphanumeric' id='u' keycode='30' label="u ㅕ" shift_label="U ㅕ" sticky="false"/>
+                <key group='alphanumeric' id='i' keycode='31' label="i ㅑ" shift_label="I ㅑ" sticky="false"/>
+                <key group='alphanumeric' id='o' keycode='32' label="o ㅐ" shift_label="O ㅒ" sticky="false"/>
+                <key group='alphanumeric' id='p' keycode='33' label="p ㅔ" shift_label="P ㅖ" sticky="false"/>
+                <key group='alphanumeric' id='s' keycode='39' label="s ㄴ" shift_label="S ㄴ" sticky="false"/>
+                <key group='alphanumeric' id='d' keycode='40' label="d ㅇ" shift_label="D ㅇ" sticky="false"/>
+                <key group='alphanumeric' id='f' keycode='41' label="f ㄹ" shift_label="F ㄹ" sticky="false"/>
+                <key group='alphanumeric' id='g' keycode='42' label="g ㅎ" shift_label="G ㅎ" sticky="false"/>
+                <key group='alphanumeric' id='h' keycode='43' label="h ㅗ" shift_label="H ㅗ" sticky="false"/>
+                <key group='alphanumeric' id='j' keycode='44' label="j ㅓ" shift_label="J ㅓ" sticky="false"/>
+                <key group='alphanumeric' id='k' keycode='45' label="k ㅏ" shift_label="K ㅏ" sticky="false"/>
+                <key group='alphanumeric' id='l' keycode='46' label="l ㅣ" shift_label="L ㅣ" sticky="false"/>
+                <key group='alphanumeric' id='x' keycode='53' label="x ㅌ" shift_label="X ㅌ" sticky="false"/>
+                <key group='alphanumeric' id='c' keycode='54' label="c ㅊ" shift_label="C ㅊ" sticky="false"/>
+                <key group='alphanumeric' id='v' keycode='55' label="v ㅍ" shift_label="V ㅍ" sticky="false"/>
+                <key group='alphanumeric' id='b' keycode='56' label="b ㅠ" shift_label="B ㅠ" sticky="false"/>
+                <key group='alphanumeric' id='n' keycode='57' label="n ㅜ" shift_label="N ㅜ" sticky="false"/>
+                <key group='alphanumeric' id='comma' keycode='59'/>
+
+                <panel id="variable_keys" layout="be,fr,cm(azerty)">
+                    <key group="alphanumeric" id="q" keycode='38' label="q ㅂ" shift_label="Q ㅃ" sticky="false"/>
+                    <key group="alphanumeric" id="a" keycode='24' label="a ㅁ" shift_label="A ㅁ" sticky="false"/>
+                    <key group="alphanumeric" id="m" keycode="47" label="m ㅡ" shift_label="M ㅡ" sticky="false"/>
+                    <key group='alphanumeric' id='w' keycode='52' label="w ㅈ" shift_label="W ㅉ" sticky="false"/>
+                    <key group='alphanumeric' id='z' keycode='25' label="z ㅋ" shift_label="Z ㅋ" sticky="false"/>
+                    <key group="alphanumeric" id="full-stop" keycode="58" />
+                </panel>
+                <panel id="variable_keys">
+                    <key group='alphanumeric' id='q' keycode='24' label="q ㅂ" shift_label="Q ㅃ" sticky="false"/>
+                    <key group='alphanumeric' id='a' keycode='38' label="a ㅁ" shift_label="A ㅁ" sticky="false"/>
+                    <key group='alphanumeric' id='m' keycode='58' label="m ㅡ" shift_label="M ㅡ" sticky="false"/>
+                    <key group='alphanumeric' id='w' keycode='25' label="w ㅈ" shift_label="W ㅉ" sticky="false"/>
+                    <key group='alphanumeric' id='z' keycode='52' label="z ㅋ" shift_label="Z ㅋ" sticky="false"/>
+                    <key group='alphanumeric' id='full-stop' keycode='60'/>
+                </panel>
+
+                <key group='bottomrow' id='LFSH.grid'/>
+                <key group='bottomrow' id='SPCE.grid' label='Space'/>
+                <key group='bottomrow' id='BKSP.grid'/>
+                <key group='bottomrow' id='RTRN.grid' label='Return' label_x_align = '0.5' popup_id="RTRN_popup"/>
+            </panel>
+
+            <!-- Panel with the click buttons -->
+            <panel filename="Grid-Alpha.svg" id="click">
+                <key group="click" id="middleclick"/>
+                <key group="click" id="secondaryclick"/>
+                <key group="click" id="doubleclick"/>
+                <key group="click" id="dragclick"/>
+                <key group="click" id="hoverclick"/>
+            </panel>
+        </box>
+    </box>
+
+    <!-- popup definition -->
+    <layout id="RTRN_popup" filename="Grid-Alpha.svg">
+        <box compact="true">
+            <key group='bottomrow' id="quit"/>
+            <key id="settings"/>
+            <key id="move"/>
+            <key id="showclick"/>
+            <key id="hide" svg_id="hide.popup" image="close.svg" group="nowordlist" />
+        </box>
+    </layout>
+
+</keyboard>

--- a/usr/share/onboard/layouts/Phone-ko.onboard
+++ b/usr/share/onboard/layouts/Phone-ko.onboard
@@ -1,0 +1,282 @@
+<?xml version="1.0" ?>
+
+<!--
+Copyright © 2013 Francesco Fumanti <francesco.fumanti@gmx.net>
+Copyright © 2013-2014, 2016 marmuta <marmvta@gmail.com>
+
+This file is part of Onboard.
+
+Onboard is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+Onboard is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<keyboard
+    id="Korean Keyboard Phone"
+    format="3.2"
+    section="system"
+    summary="Mobile keyboard for small screens" >
+
+  <include file="key_defs.xml"/>
+
+  <!-- box containing all the keys and buttons -->
+  <!-- the rows of keys on the Onboard keyboard are counted bottom to top starting with 1 -->
+  <box border="0.5" spacing="2.0" orientation="vertical">
+
+    <!--- word suggestions -->
+    <panel filename="Phone-Alpha.svg">
+        <include file='word_suggestions.xml'/>
+    </panel>
+
+    <key_template button="true" id="layer0" show_active="false"/>
+    
+    <panel>
+      <box orientation="vertical">
+      <!-- alpha and numbers layers -->
+        <panel>
+            <!-- Cyrillic keymaps-->
+            <panel id="alpha-keys" filename="Phone-Alpha.svg" layer="alpha" layout="ru,ua,by,bg,tj,ge(os),az(cyrillic),mn,mk">
+            <!-- row 2,3 and 4 of the layers -->
+            <!-- row 4 -->
+            <key group="alphanumeric" id="AD01" svg_id="AD01-cyr"/>
+            <key group="alphanumeric" id="AD02" svg_id="AD02-cyr"/>
+            <key group="alphanumeric" id="AD03" svg_id="AD03-cyr"/>
+            <key group="alphanumeric" id="AD04" svg_id="AD04-cyr"/>
+            <key group="alphanumeric" id="AD05" svg_id="AD05-cyr"/>
+            <key group="alphanumeric" id="AD06" svg_id="AD06-cyr"/>
+            <key group="alphanumeric" id="AD07" svg_id="AD07-cyr"/>
+            <key group="alphanumeric" id="AD08" svg_id="AD08-cyr"/>
+            <key group="alphanumeric" id="AD09" svg_id="AD09-cyr"/>
+            <key group="alphanumeric" id="AD10" svg_id="AD10-cyr"/>
+            <key group="alphanumeric" id="AD11" svg_id="AD11-cyr"/>
+
+            <!-- row 3 -->
+            <key group="alphanumeric" id="AC01" svg_id="AC01-cyr"/>
+            <key group="alphanumeric" id="AC02" svg_id="AC02-cyr"/>
+            <key group="alphanumeric" id="AC03" svg_id="AC03-cyr"/>
+            <key group="alphanumeric" id="AC04" svg_id="AC04-cyr"/>
+            <key group="alphanumeric" id="AC05" svg_id="AC05-cyr"/>
+            <key group="alphanumeric" id="AC06" svg_id="AC06-cyr"/>
+            <key group="alphanumeric" id="AC07" svg_id="AC07-cyr"/>
+            <key group="alphanumeric" id="AC08" svg_id="AC08-cyr"/>
+            <key group="alphanumeric" id="AC09" svg_id="AC09-cyr"/>
+            <key group="alphanumeric" id="AC10" svg_id="AC10-cyr"/>
+            <key group="alphanumeric" id="AC11" svg_id="AC11-cyr" keycode="35" layout="ru,tj,az(cyrillic)"/>
+            <key group="alphanumeric" id="AC11" svg_id="AC11-cyr" keycode="51" layout="ua"/>
+            <key group="alphanumeric" id="AC11" svg_id="AC11-cyr"/>
+
+            <!-- row 2 -->
+            <key group="shifts" id="LFSH.like_rtrn" svg_id="LFSH-cyr"/>
+            <key group="alphanumeric" id="AB01" svg_id="AB01-cyr"/>
+            <key group="alphanumeric" id="AB02" svg_id="AB02-cyr"/>
+            <key group="alphanumeric" id="AB03" svg_id="AB03-cyr"/>
+            <key group="alphanumeric" id="AB04" svg_id="AB04-cyr"/>
+            <key group="alphanumeric" id="AB05" svg_id="AB05-cyr"/>
+            <key group="alphanumeric" id="AB06" svg_id="AB06-cyr"/>
+            <key group="alphanumeric" id="AB07" svg_id="AB07-cyr"/>
+            <key group="alphanumeric" id="AB08" svg_id="AB08-cyr"/>
+            <key group="alphanumeric" id="AB09" svg_id="AB09-cyr"/>
+            <key group="alphanumeric" id="AB09" svg_id="AB09-cyr"/>
+            <key group="alphanumeric" id="AB10" svg_id="AB10-cyr" keycode="48" layout="ru,ua,tj,az(cyrillic)"/>
+            <key group="alphanumeric" id="AB10" svg_id="AB10-cyr" keycode="49" layout="ge(os)"/> <!-- not ideal, but sacrifice ESC instead? -->
+            <key group="alphanumeric" id="AB10" svg_id="AB10-cyr" keycode="51" layout="mk"/>
+            <key group="alphanumeric" id="AB10" svg_id="AB10-cyr"/>
+            <key group="bottomrow" id="BKSP" svg_id="BKSP-cyr"/>
+          </panel>
+
+          <!-- Latin and other keymaps -->
+          <panel id="alpha-keys" filename="Phone-Alpha.svg" layer="alpha">
+            <!-- row 2,3 and 4 of the layers -->
+            <!-- row 4 -->
+            <key group="alphanumeric" id="AD01" keycode="24" label="q ㅂ" shift_label="Q ㅃ" sticky="false"/>
+            <key group="alphanumeric" id="AD02" keycode="25" label="w ㅈ" shift_label="W ㅉ" sticky="false"/>
+            <key group="alphanumeric" id="AD03" keycode="26" label="e ㄷ" shift_label="E ㄸ" sticky="false"/>
+            <key group="alphanumeric" id="AD04" keycode="27" label="r ㄱ" shift_label="R ㄲ" sticky="false"/>
+            <key group="alphanumeric" id="AD05" keycode="28" label="t ㅅ" shift_label="T ㅆ" sticky="false"/>
+            <key group="alphanumeric" id="AD06" keycode="29" label="y ㅛ" shift_label="Y ㅛ" sticky="false"/>
+            <key group="alphanumeric" id="AD07" keycode="30" label="u ㅕ" shift_label="U ㅕ" sticky="false"/>
+            <key group="alphanumeric" id="AD08" keycode="31" label="i ㅑ" shift_label="I ㅑ" sticky="false"/>
+            <key group="alphanumeric" id="AD09" keycode="32" label="o ㅐ" shift_label="O ㅒ" sticky="false"/>
+            <key group="alphanumeric" id="AD10" keycode="33" label="p ㅔ" shift_label="P ㅖ" sticky="false"/>
+
+            <!-- row 3 -->
+            <key group="alphanumeric" id="AC01" keycode="38" label="a ㅁ" shift_label="A ㅁ" sticky="false"/>
+            <key group="alphanumeric" id="AC02" keycode="39" label="s ㄴ" shift_label="S ㄴ" sticky="false"/>
+            <key group="alphanumeric" id="AC03" keycode="40" label="d ㅇ" shift_label="D ㅇ" sticky="false"/>
+            <key group="alphanumeric" id="AC04" keycode="41" label="f ㄹ" shift_label="F ㄹ" sticky="false"/>
+            <key group="alphanumeric" id="AC05" keycode="42" label="g ㅎ" shift_label="G ㅎ" sticky="false"/>
+            <key group="alphanumeric" id="AC06" keycode="43" label="h ㅗ" shift_label="H ㅗ" sticky="false"/>
+            <key group="alphanumeric" id="AC07" keycode="44" label="j ㅓ" shift_label="J ㅓ" sticky="false"/>
+            <key group="alphanumeric" id="AC08" keycode="45" label="k ㅏ" shift_label="K ㅏ" sticky="false"/>
+            <key group="alphanumeric" id="AC09" keycode="46" label="l ㅣ" shift_label="L ㅣ" sticky="false"/>
+            <key group="alphanumeric" id="AC10" keycode="47" layout="be,fr,cm(azerty)"/>
+            <key group="alphanumeric" id="AC10" char="'" label="'"/>
+
+            <!-- row 2 -->
+            <key group="shifts" id="LFSH.like_rtrn"/>
+            <key group="alphanumeric" id="AB01" keycode="52" label="z ㅋ" shift_label="Z ㅋ" sticky="false"/>
+            <key group="alphanumeric" id="AB02" keycode="53" label="x ㅌ" shift_label="X ㅌ" sticky="false"/>
+            <key group="alphanumeric" id="AB03" keycode="54" label="c ㅊ" shift_label="C ㅊ" sticky="false"/>
+            <key group="alphanumeric" id="AB04" keycode="55" label="v ㅍ" shift_label="V ㅍ" sticky="false"/>
+            <key group="alphanumeric" id="AB05" keycode="56" label="b ㅠ" shift_label="B ㅠ" sticky="false"/>
+            <key group="alphanumeric" id="AB06" keycode="57" label="n ㅜ" shift_label="N ㅜ" sticky="false"/>
+            <key group="alphanumeric" id="AB07" char="'" label="'" layout="be,fr,cm(azerty)"/>
+            <key group="alphanumeric" id="AB07" keycode="58" label="m ㅡ" shift_label="M ㅡ" sticky="false"/>
+            <key group="bottomrow" id="BKSP"/>
+          </panel>
+
+          <panel filename="Phone-Numbers.svg" layer="numbers">
+            <!-- row 4 -->
+            <key group="alphanumeric" id="BD01" keysym="0x31" label="1" unlatch_layer="false"/>
+            <key group="alphanumeric" id="BD02" keysym="0x32" label="2" unlatch_layer="false"/>
+            <key group="alphanumeric" id="BD03" keysym="0x33" label="3" unlatch_layer="false"/>
+            <key group="alphanumeric" id="BD04" keysym="0x34" label="4" unlatch_layer="false"/>
+            <key group="alphanumeric" id="BD05" keysym="0x35" label="5" unlatch_layer="false"/>
+            <key group="alphanumeric" id="BD06" keysym="0x36" label="6" unlatch_layer="false"/>
+            <key group="alphanumeric" id="BD07" keysym="0x37" label="7" unlatch_layer="false"/>
+            <key group="alphanumeric" id="BD08" keysym="0x38" label="8" unlatch_layer="false"/>
+            <key group="alphanumeric" id="BD09" keysym="0x39" label="9" unlatch_layer="false"/>
+            <key group="alphanumeric" id="BD10" keysym="0x30" label="0" unlatch_layer="false"/>
+
+            <!-- row 3 -->
+            <key group="alphanumeric" id="TAB"/>
+            <key group="alphanumeric" id="BC02" char="#" label="#"/>
+            <key group="alphanumeric" id="BC03" char="%" label="%"/>
+            <key group="alphanumeric" id="BC04" char="*" label="*"/>
+            <key group="alphanumeric" id="BC05" char="/" label="/"/>
+            <key group="alphanumeric" id="BC06" char="+" label="+"/>
+            <key group="alphanumeric" id="BC07" char="-" label="-"/>
+            <key group="alphanumeric" id="BC08" char="(" label="("/>
+            <key group="alphanumeric" id="BC09" char=")" label=")"/>
+            <key group="alphanumeric" id="BC10" char="'" label="'"/>
+
+            <!-- row 2 -->
+            <key group="bottomrow" id="layer2.like_rtrn" label="1/3" image=""/>
+            <key group="alphanumeric" id="BB01" char=";" label=";"/>
+            <key group="alphanumeric" id="BB02" char="@" label="@"/>
+            <key group="alphanumeric" id="BB03" char="=" label="="/>
+            <key group="alphanumeric" id="BB04" char="?" label="?"/>
+            <key group="alphanumeric" id="BB05" char="!" label="!"/>
+            <key group="alphanumeric" id="BB06" char=":" label=":"/>
+            <key group="alphanumeric" id="BB07" char="&quot;" label="&quot;" />
+            <key group="bottomrow" id="BKSP" unlatch_layer="false"/>
+          </panel>
+        </panel>
+
+        <panel>
+          <panel filename="Phone-Alpha.svg">
+            <!-- row 1 of the layer -->
+            <key group="bottomrow" id="layer1.like_rtrn" label="12!@"/>
+            <key group="alphanumeric" id="AA01" char="," label="," unlatch_layer="false"/>
+            <key group="bottomrow" id="SPCE"/>
+            <key group="alphanumeric" id="AA02" char="." label="." unlatch_layer="false"/>
+            <key group="bottomrow" id="RTRN" popup_id="RTRN_popup"/>
+          </panel>          
+        </panel>     
+      </box>
+      <panel filename="Phone-Syms.svg" layer="syms">
+        <!-- row 4 -->
+        <key group="alphanumeric" id="CD01" char="~" label="~"/>
+        <key group="alphanumeric" id="CD02" char="_" label="_"/>
+        <key group="alphanumeric" id="CD03" char="|" label="|"/>
+        <key group="alphanumeric" id="CD04" char="\" label="\"/>
+        <key group="alphanumeric" id="CD05" char="&lt;" label="&lt;"/>
+        <key group="alphanumeric" id="CD06" char="&gt;" label="&gt;"/>
+        <key group="alphanumeric" id="CD07" char="{" label="{"/>
+        <key group="alphanumeric" id="CD08" char="}" label="}"/>
+        <key group="alphanumeric" id="CD09" char="[" label="["/>
+        <key group="alphanumeric" id="CD10" char="]" label="]"/>
+        <!-- row 3 -->
+
+        <key group="alphanumeric" id="CC01" char="$" label="$"/>
+        <key group="alphanumeric" id="CC02" label="€" keysym="8364"/>
+        <key group="alphanumeric" id="CC03" label="¥" char="¥"/>
+        <key group="alphanumeric" id="CC04" label="₽" char="₽"/>
+        <key group="alphanumeric" id="CC05" label="₮" char="₮" layout="mn"/>  <!-- Mongolian tögrög -->
+        <key group="alphanumeric" id="CC05" label="£" char="£"/>
+        <key group="alphanumeric" id="CC06" label="&amp;" char="&amp;"/>
+        <key group="alphanumeric" id="CC07" char="§" label="§"/>
+        <key group="alphanumeric" id="CC08" char="^" label="^"/>
+        <key group="alphanumeric" id="CC09" char="`" label="`"/>
+        <key group="alphanumeric" id="CC10" char="°" label="°"/>
+        <!-- row 2 -->
+        <key group="bottomrow" id="layer3.like_rtrn" label="2/3"/>
+        <key group="alphanumeric" id="CB01" char="”" label="”"/>
+        <key group="alphanumeric" id="CB02" char="«" label="«"/>
+        <key group="alphanumeric" id="CB03" char="»" label="»"/>
+        <key group="alphanumeric" id="CB04" char="¿" label="¿"/>
+        <key group="alphanumeric" id="CB05" char="¡" label="¡"/>
+        <key group="alphanumeric" id="CB06" char="®" label="®"/>
+        <key group="alphanumeric" id="CB07" char="©" label="©"/>
+        <key group="bottomrow" id="BKSP"/>
+        <!-- row 1 -->
+        <key group="bottomrow" id="layer0.like_rtrn"/>
+        <key group="alphanumeric" id="CA01" char="„" label="„"/>
+        <key group="bottomrow" id="SPCE"/>
+        <key group="alphanumeric" id="CA02" char="…" label="…"/>
+        <key group="bottomrow" id="RTRN" popup_id="RTRN_popup"/>
+      </panel>
+      <panel filename="Phone-Emoji.svg" layer="emoji">
+        <!-- row 4 -->
+        <key group="symbol" id="DD01" char="☺" label="☺"/> <!-- U+263A WHITE SMILING FACE -->
+        <key group="symbol" id="DD02" char="😊" label="😊"/> <!-- U+1F60A SMILING FACE WITH SMILING EYES -->
+        <key group="symbol" id="DD03" char="😄" label="😄"/> <!-- U+1F604 SMILING FACE WITH OPEN MOUTH AND SMILING EYES -->
+        <key group="symbol" id="DD04" char="😉" label="😉"/> <!-- U+1F609 WINKING FACE -->
+        <key group="symbol" id="DD05" char="😜" label="😜"/> <!-- U+1F61C FACE WITH STUCK-OUT TONGUE AND WINKING EYE -->
+        <key group="symbol" id="DD06" char="😚" label="😚"/> <!-- U+1F61A KISSING FACE WITH CLOSED EYES -->
+        <key group="symbol" id="DD07" char="😎" label="😎"/> <!-- U+1F60E SMILING FACE WITH SUNGLASSES -->
+        <key group="symbol" id="DD08" char="😇" label="😇"/> <!-- U+1F607 SMILING FACE WITH HALO -->
+        <key group="symbol" id="DD09" char="♀" label="♀"/> <!-- U+2640 FEMALE SIGN -->
+        <key group="symbol" id="DD10" char="☼" label="☼"/> <!-- U+263C WHITE SUN WITH RAYS -->
+        <!-- row 3 -->
+        <key group="symbol" id="DC01" char="☹" label="☹"/> <!-- U+2639 WHITE FROWNING FACE -->
+        <key group="symbol" id="DC02" char="😠" label="😠"/> <!-- U+1F620 ANGRY FACE -->
+        <key group="symbol" id="DC03" char="😢" label="😢"/> <!-- U+1F622 CRYING FACE -->
+        <key group="symbol" id="DC04" char="😲" label="😲"/> <!-- U+1F632 ASTONISHED FACE -->
+        <key group="symbol" id="DC05" char="😖" label="😖"/> <!-- U+1F616 CONFOUNDED FACE -->
+        <key group="symbol" id="DC06" char="😩" label="😩"/> <!-- U+1F629 WEARY FACE -->
+        <key group="symbol" id="DC07" char="😋" label="😋"/> <!-- U+1F60B FACE SAVOURING DELICIOUS FOOD -->
+        <key group="symbol" id="DC08" char="😈" label="😈"/> <!-- U+1F608 SMILING FACE WITH HORNS -->
+        <key group="symbol" id="DC09" char="♂" label="♂"/> <!-- U+2642 MALE SIGN -->
+        <key group="symbol" id="DC10" char="☾" label="☾"/> <!-- U+263E LAST QUARTER MOON -->
+        <!-- row 2 -->
+        <key group="bottomrow" id="layer1.like_rtrn" label="3/3" image=";"/>
+        <key group="symbol" id="DB01" char="♡" label="♡"/> <!-- U+2661 WHITE HEART SUIT -->
+        <key group="symbol" id="DB02" char="♫" label="♫"/> <!-- U+266B BEAMED EIGHTH NOTE -->
+        <key group="symbol" id="DB03" char="☏" label="☏"/> <!-- U+260F WHITE TELEPHONE -->
+        <key group="symbol" id="DB04" char="✉" label="✉"/> <!-- U+2709 ENVELOPE -->
+        <key group="symbol" id="DB05" char="☂" label="☂"/> <!-- U+2602 UMBRELLA -->
+        <key group="symbol" id="DB06" char="☮" label="☮"/> <!-- U+262E PEACE SYMBOL -->
+        <key group="symbol" id="DB07" char="☆" label="☆"/> <!-- U+2606 WHITE STAR -->
+        <key group="bottomrow" id="BKSP"/>
+        <!-- row 1 of the layers -->
+        <key group="bottomrow" id="layer0.like_rtrn"/>
+        <key group="symbol" id="DA01" char="☢" label="☢"/> <!-- U+2622 RADIOACTIVE SIGN -->
+        <key group="bottomrow" id="SPCE"/>
+        <key group="symbol" id="DA02" char="☯" label="☯"/> <!-- U+262F YIN YANG -->
+        <key group="bottomrow" id="RTRN" popup_id="RTRN_popup"/>
+      </panel>
+
+    </panel>
+
+  </box>
+
+  <!-- popup definition -->
+  <layout id="RTRN_popup" filename="Phone-Alpha.svg">
+    <box compact="true">
+        <key id="settings"/>
+        <key id="move"/>
+        <key id="hide" svg_id="hide.popup" image="close.svg" group="nowordlist" />
+    </box>
+  </layout>
+
+</keyboard>

--- a/usr/share/onboard/layouts/Small-ko.onboard
+++ b/usr/share/onboard/layouts/Small-ko.onboard
@@ -1,0 +1,435 @@
+<?xml version="1.0" ?>
+<!--
+Copyright © 2013 Francesco Fumanti <francesco.fumanti@gmx.net>
+Copyright © 2013-2014, 2016 marmuta <marmvta@gmail.com>
+
+This file is part of Onboard.
+
+Onboard is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+Onboard is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+-->
+<keyboard format="3.2" id="Korean Keyboard Small" section="system" summary="Space efficient desktop keyboard">
+  <include file="key_defs.xml"/>
+  <box border="0.5" orientation="vertical" spacing="1.5">
+    <!--- word suggestions -->
+    <panel filename="Small-Alpha.svg">
+      <include file="word_suggestions.xml"/>
+    </panel>
+    <key_template button="true" id="layer0" show_active="false"/>
+    <key_template button="true" id="layer1" label="12?"/>
+    <key_template button="true" id="layer2" label="Sym"/>
+    <key_template button="true" id="layer3" image="" label="Fn"/>
+    <key_template button="true" id="layer4" image="snippets.svg" label=""/>
+    <key_template button="true" id="layer5" label="☺"/>
+    <box>
+      <panel>
+        <!-- layer0 -->
+
+        <!-- Cyrillic keymaps -->
+        <panel id="alpha-keys" filename="Small-Alpha.svg" layer="alpha" layout="ru,ua,by,bg,tj,ge(os),az(cyrillic),mn,mk">
+          <!-- row 4 -->
+          <key group="bottomrow" id="ESC" label_margin=", 2"/>
+          <key group="alphanumeric" id="AD01" svg_id="AD01-cyr"/>
+          <key group="alphanumeric" id="AD02" svg_id="AD02-cyr"/>
+          <key group="alphanumeric" id="AD03" svg_id="AD03-cyr"/>
+          <key group="alphanumeric" id="AD04" svg_id="AD04-cyr"/>
+          <key group="alphanumeric" id="AD05" svg_id="AD05-cyr"/>
+          <key group="alphanumeric" id="AD06" svg_id="AD06-cyr"/>
+          <key group="alphanumeric" id="AD07" svg_id="AD07-cyr"/>
+          <key group="alphanumeric" id="AD08" svg_id="AD08-cyr"/>
+          <key group="alphanumeric" id="AD09" svg_id="AD09-cyr"/>
+          <key group="alphanumeric" id="AD10" svg_id="AD10-cyr"/>
+          <key group="alphanumeric" id="AD11" svg_id="AD11-cyr"/>
+          <key group="bottomrow" id="BKSP"/>
+          <!-- row 3 -->
+          <key group="bottomrow" id="TAB"/>
+          <key group="alphanumeric" id="AC01" svg_id="AC01-cyr"/>
+          <key group="alphanumeric" id="AC02" svg_id="AC02-cyr"/>
+          <key group="alphanumeric" id="AC03" svg_id="AC03-cyr"/>
+          <key group="alphanumeric" id="AC04" svg_id="AC04-cyr"/>
+          <key group="alphanumeric" id="AC05" svg_id="AC05-cyr"/>
+          <key group="alphanumeric" id="AC06" svg_id="AC06-cyr"/>
+          <key group="alphanumeric" id="AC07" svg_id="AC07-cyr"/>
+          <key group="alphanumeric" id="AC08" svg_id="AC08-cyr"/>
+          <key group="alphanumeric" id="AC09" svg_id="AC09-cyr"/>
+          <key group="alphanumeric" id="AC10" svg_id="AC10-cyr"/>
+          <key group="alphanumeric" id="AC11" svg_id="AC11-cyr" keycode="35" layout="ru,tj,az(cyrillic)"/>
+          <key group="alphanumeric" id="AC11" svg_id="AC11-cyr" keycode="51" layout="ua"/>
+          <key group="alphanumeric" id="AC11" svg_id="AC11-cyr"/>
+          <key group="bottomrow" id="DELE"/>
+          <!-- row 2 -->
+          <key group="shifts" id="LFSH"/>
+          <key group="alphanumeric" id="AB01" svg_id="AB01-cyr"/>
+          <key group="alphanumeric" id="AB02" svg_id="AB02-cyr"/>
+          <key group="alphanumeric" id="AB03" svg_id="AB03-cyr"/>
+          <key group="alphanumeric" id="AB04" svg_id="AB04-cyr"/>
+          <key group="alphanumeric" id="AB05" svg_id="AB05-cyr"/>
+          <key group="alphanumeric" id="AB06" svg_id="AB06-cyr"/>
+          <key group="alphanumeric" id="AB07" svg_id="AB07-cyr"/>
+          <key group="alphanumeric" id="AB08" svg_id="AB08-cyr"/>
+          <key group="alphanumeric" id="AB09" svg_id="AB09-cyr"/>
+          <key group="alphanumeric" id="AB09" svg_id="AB09-cyr"/>
+          <key group="alphanumeric" id="AB10" svg_id="AB10-cyr" keycode="48" layout="ru,ua,tj,az(cyrillic)"/>
+          <key group="alphanumeric" id="AB10" svg_id="AB10-cyr" keycode="49" layout="ge(os)"/> <!-- not ideal, but sacrifice ESC instead? -->
+          <key group="alphanumeric" id="AB10" svg_id="AB10-cyr" keycode="51" layout="mk"/>
+          <key group="alphanumeric" id="AB10" svg_id="AB10-cyr"/>
+          <key group="misc" id="RTRN" popup_id="RTRN_popup"/>
+          <key group="shifts" id="RTSH"/>
+        </panel>
+
+        <!-- Latin and other keymaps -->
+        <panel id="alpha-keys" filename="Small-Alpha.svg" layer="alpha">
+          <!-- row 4 -->
+          <key group="bottomrow" id="ESC" label_margin=", 2"/>
+          <key group="alphanumeric" id="AD01" keycode="24" label="q ㅂ" shift_label="Q ㅃ" sticky="false"/>
+          <key group="alphanumeric" id="AD02" keycode="25" label="w ㅈ" shift_label="W ㅉ" sticky="false"/>
+          <key group="alphanumeric" id="AD03" keycode="26" label="e ㄷ" shift_label="E ㄸ" sticky="false"/>
+          <key group="alphanumeric" id="AD04" keycode="27" label="r ㄱ" shift_label="R ㄲ" sticky="false"/>
+          <key group="alphanumeric" id="AD05" keycode="28" label="t ㅅ" shift_label="T ㅆ" sticky="false"/>
+          <key group="alphanumeric" id="AD06" keycode="29" label="y ㅛ" shift_label="Y ㅛ" sticky="false"/>
+          <key group="alphanumeric" id="AD07" keycode="30" label="u ㅕ" shift_label="U ㅕ" sticky="false"/>
+          <key group="alphanumeric" id="AD08" keycode="31" label="i ㅑ" shift_label="I ㅑ" sticky="false"/>
+          <key group="alphanumeric" id="AD09" keycode="32" label="o ㅐ" shift_label="O ㅒ" sticky="false"/>
+          <key group="alphanumeric" id="AD10" keycode="33" label="p ㅔ" shift_label="P ㅖ" sticky="false"/>
+          <key group="bottomrow" id="BKSP"/>
+          <!-- row 3 -->
+          <key group="bottomrow" id="TAB"/>
+          <key group="alphanumeric" id="AC01" keycode="38" label="a ㅁ" shift_label="A ㅁ" sticky="false"/>
+          <key group="alphanumeric" id="AC02" keycode="39" label="s ㄴ" shift_label="S ㄴ" sticky="false"/>
+          <key group="alphanumeric" id="AC03" keycode="40" label="d ㅇ" shift_label="D ㅇ" sticky="false"/>
+          <key group="alphanumeric" id="AC04" keycode="41" label="f ㄹ" shift_label="F ㄹ" sticky="false"/>
+          <key group="alphanumeric" id="AC05" keycode="42" label="g ㅎ" shift_label="G ㅎ" sticky="false"/>
+          <key group="alphanumeric" id="AC06" keycode="43" label="h ㅗ" shift_label="H ㅗ" sticky="false"/>
+          <key group="alphanumeric" id="AC07" keycode="44" label="j ㅓ" shift_label="J ㅓ" sticky="false"/>
+          <key group="alphanumeric" id="AC08" keycode="45" label="k ㅏ" shift_label="K ㅏ" sticky="false"/>
+          <key group="alphanumeric" id="AC09" keycode="46" label="l ㅣ" shift_label="L ㅣ" sticky="false"/>
+          <key group="alphanumeric" id="AC10" keycode="47" layout="be,fr,cm(azerty)"/>
+          <key group="alphanumeric" id="AC10" label="'" char="'" />
+          <key group="bottomrow" id="DELE"/>
+          <!-- row 2 -->
+          <key group="shifts" id="LFSH"/>
+          <key group="alphanumeric" id="AB01" keycode="52" label="z ㅋ" shift_label="Z ㅋ" sticky="false"/>
+          <key group="alphanumeric" id="AB02" keycode="53" label="x ㅌ" shift_label="X ㅌ" sticky="false"/>
+          <key group="alphanumeric" id="AB03" keycode="54" label="c ㅊ" shift_label="C ㅊ" sticky="false"/>
+          <key group="alphanumeric" id="AB04" keycode="55" label="v ㅍ" shift_label="V ㅍ" sticky="false"/>
+          <key group="alphanumeric" id="AB05" keycode="56" label="b ㅠ" shift_label="B ㅠ" sticky="false"/>
+          <key group="alphanumeric" id="AB06" keycode="57" label="n ㅜ" shift_label="N ㅜ" sticky="false"/>
+          <key group="alphanumeric" id="AB07" label="'" char="'" layout="be,fr,cm(azerty)"/>
+          <key group="alphanumeric" id="AB07" keycode="58" label="m ㅡ" shift_label="M ㅡ" sticky="false"/>
+          <key group="alphanumeric" id="AB08" label="," char=","/>
+          <key group="alphanumeric" id="AB09" label="." char="."/>
+          <key group="misc" id="RTRN" popup_id="RTRN_popup"/>
+          <key group="shifts" id="RTSH"/>
+        </panel>
+
+        <!-- layer1 -->
+        <panel filename="Small-Numbers.svg" layer="numbers">
+          <!-- row 4, numbers layer -->
+          <key group="bottomrow" id="ESC"/>
+          <key group="alphanumeric" id="BD01" keysym="0x31" label="1"/>
+          <key group="alphanumeric" id="BD02" keysym="0x32" label="2"/>
+          <key group="alphanumeric" id="BD03" keysym="0x33" label="3"/>
+          <key group="alphanumeric" id="BD04" keysym="0x34" label="4"/>
+          <key group="alphanumeric" id="BD05" keysym="0x35" label="5"/>
+          <key group="alphanumeric" id="BD06" keysym="0x36" label="6"/>
+          <key group="alphanumeric" id="BD07" keysym="0x37" label="7"/>
+          <key group="alphanumeric" id="BD08" keysym="0x38" label="8"/>
+          <key group="alphanumeric" id="BD09" keysym="0x39" label="9"/>
+          <key group="alphanumeric" id="BD10" keysym="0x30" label="0"/>
+          <key group="bottomrow" id="BKSP"/>
+          <!-- row 3, numbers layer -->
+          <key group="bottomrow" id="TAB"/>
+          <key char="#" group="alphanumeric" id="BC01" label="#"/>
+          <key char="%" group="alphanumeric" id="BC02" label="%"/>
+          <key char="+" group="alphanumeric" id="BC03" label="+"/>
+          <key char="-" group="alphanumeric" id="BC04" label="-"/>
+          <key char="*" group="alphanumeric" id="BC05" label="*"/>
+          <key char="/" group="alphanumeric" id="BC06" label="/"/>
+          <key char="\" group="alphanumeric" id="BC07" label="\"/>
+          <key char="(" group="alphanumeric" id="BC08" label="("/>
+          <key char=")" group="alphanumeric" id="BC09" label=")"/>
+          <key char="'" group="alphanumeric" id="BC10" label="'"/>
+          <key group="bottomrow" id="DELE"/>
+          <!-- row 2, numbers layer -->
+          <key group="bottomrow" id="layer5"/>
+          <key char="@" group="alphanumeric" id="BB01" label="@"/>
+          <key char="=" group="alphanumeric" id="BB02" label="="/>
+          <key char="&quot;" group="alphanumeric" id="BB03" label="&quot;"/>
+          <key char="?" group="alphanumeric" id="BB04" label="?"/>
+          <key char="!" group="alphanumeric" id="BB05" label="!"/>
+          <key char=";" group="alphanumeric" id="BB06" label=";"/>
+          <key char=":" group="alphanumeric" id="BB07" label=":"/>
+          <key char="," group="alphanumeric" id="BB08" label=","/>
+          <key char="." group="alphanumeric" id="BB09" label="."/>
+          <key group="misc" id="RTRN" popup_id="RTRN_popup"/>
+        </panel>
+        <!-- layer2 -->
+        <panel filename="Small-Syms.svg" layer="syms">
+          <!-- row 4 -->
+          <key group="bottomrow" id="ESC"/>
+          <key char="`" group="alphanumeric" id="CD01" label="`"/>
+          <key char="~" group="alphanumeric" id="CD02" label="~"/>
+          <key char="_" group="alphanumeric" id="CD03" label="_"/>
+          <key char="&lt;" group="alphanumeric" id="CD04" label="&lt;"/>
+          <key char="|" group="alphanumeric" id="CD05" label="|"/>
+          <key char="&gt;" group="alphanumeric" id="CD06" label="&gt;"/>
+          <key char="{" group="alphanumeric" id="CD07" label="{"/>
+          <key char="}" group="alphanumeric" id="CD08" label="}"/>
+          <key char="[" group="alphanumeric" id="CD09" label="["/>
+          <key char="]" group="alphanumeric" id="CD10" label="]"/>
+          <key group="bottomrow" id="BKSP"/>
+          <!-- row 3 -->
+          <key group="bottomrow" id="TAB"/>
+          <key char="$" group="alphanumeric" id="CC01" label="$"/>
+          <key group="alphanumeric" id="CC02" label="€" keysym="8364"/>
+          <key group="alphanumeric" id="CC03" label="¥" char="¥"/>
+          <key group="alphanumeric" id="CC04" label="₽" char="₽"/>
+          <key group="alphanumeric" id="CC05" label="₮" char="₮" layout="mn"/>  <!-- Mongolian tögrög -->
+          <key group="alphanumeric" id="CC05" label="£" char="£"/>
+          <key group="alphanumeric" id="CC06" label="&amp;" char="&amp;"/>
+          <key char="§" group="alphanumeric" id="CC07" label="§"/>
+          <key char="^" group="alphanumeric" id="CC08" label="^"/>
+          <key char="°" group="alphanumeric" id="CC09" label="°"/>
+          <key char="…" group="alphanumeric" id="CC10" label="…"/>
+          <key group="bottomrow" id="DELE"/>
+          <!-- row 2 -->
+          <key group="bottomrow" id="layer5"/>
+          <key char="„" group="alphanumeric" id="CB01" label="„"/>
+          <key char="”" group="alphanumeric" id="CB02" label="”"/>
+          <key char="«" group="alphanumeric" id="CB03" label="«"/>
+          <key char="»" group="alphanumeric" id="CB04" label="»"/>
+          <key char="¿" group="alphanumeric" id="CB05" label="¿"/>
+          <key char="¡" group="alphanumeric" id="CB06" label="¡"/>
+          <key char="™" group="alphanumeric" id="CB07" label="™"/>
+          <key char="®" group="alphanumeric" id="CB08" label="®"/>
+          <key char="©" group="alphanumeric" id="CB09" label="©"/>
+          <key group="misc" id="RTRN" popup_id="RTRN_popup"/>
+        </panel>
+        <!-- layer3 -->
+        <panel filename="Small-Fn.svg" layer="functionkeys">
+          <key group="bottomrow" id="ESC"/>
+          <key group="fkeys" id="F1.rows_of_six"/>
+          <key group="fkeys" id="F2.rows_of_six"/>
+          <key group="fkeys" id="F3.rows_of_six"/>
+          <key group="fkeys" id="F4.rows_of_six"/>
+          <key group="fkeys" id="F5.rows_of_six"/>
+          <key group="fkeys" id="F6.rows_of_six"/>
+          <key group="fkeys" id="F7.rows_of_six"/>
+          <key group="fkeys" id="F8.rows_of_six"/>
+          <key group="fkeys" id="F9.rows_of_six"/>
+          <key group="fkeys" id="F10.rows_of_six"/>
+          <key group="fkeys" id="F11.rows_of_six"/>
+          <key group="fkeys" id="F12.rows_of_six" label_margin="2"/>
+          <key group="editing" id="Prnt" scan_priority="1"/>
+          <key group="editing" id="Pause" scan_priority="1"/>
+          <key group="editing" id="Scroll" scan_priority="1"/>
+          <key group="editing" id="INS"/>
+          <key group="editing" id="HOME"/>
+          <key group="editing" id="PGUP"/>
+          <key group="editing" id="DELE" image="" label="Del"/>
+          <key group="editing" id="END"/>
+          <key group="editing" id="PGDN"/>
+          <key group="bottomrow" id="TAB"/>
+          <key group="bottomrow" id="layer5"/>
+        </panel>
+        <!-- layer4 -->
+        <panel filename="Small-Snippets.svg" layer="snippets">
+          <key group="snippets" id="m0"/>
+          <key group="snippets" id="m1"/>
+          <key group="snippets" id="m2"/>
+          <key group="snippets" id="m3"/>
+          <key group="snippets" id="m4"/>
+          <key group="snippets" id="m5"/>
+          <key group="snippets" id="m6"/>
+          <key group="snippets" id="m7"/>
+          <key group="snippets" id="m8"/>
+          <key group="snippets" id="m9"/>
+          <key group="snippets" id="m10"/>
+          <key group="snippets" id="m11"/>
+          <key expand="false" group="bottomrow" id="hide"/>
+          <key expand="false" group="bottomrow" id="move"/>
+          <key group="click_control" id="showclick"/>
+          <key group="bottomrow" id="layer5" label="☺"/>
+          <key group="bottomrow" id="layer0"/>
+        </panel>
+        <!-- layer5 -->
+        <panel filename="Small-Emoji.svg" layer="emoji">
+          <!-- row 4 -->
+          <key group="bottomrow" id="ESC"/>
+          <key char="☺" group="symbol" id="DD01" label="☺" tooltip="Smiling face"/>
+          <!-- U+263A -->
+          <key char="😊" group="symbol" id="DD02" label="😊" tooltip="Smiling face with smiling eyes"/>
+          <!-- U+1F60A -->
+          <key char="😄" group="symbol" id="DD03" label="😄" tooltip="Smiling face with open mouth and smiling eyes"/>
+          <!-- U+1F604 -->
+          <key char="😉" group="symbol" id="DD04" label="😉" tooltip="Winking face"/>
+          <!-- U+1F609 -->
+          <key char="😜" group="symbol" id="DD05" label="😜" tooltip="Face with stuck-out tongue and winking eye"/>
+          <!-- U+1F61C -->
+          <key char="😚" group="symbol" id="DD06" label="😚" tooltip="Kissing face with closed eyes"/>
+          <!-- U+1F61A -->
+          <key char="😎" group="symbol" id="DD07" label="😎" tooltip="Smiling face with sunglasses"/>
+          <!-- U+1F60E -->
+          <key char="😇" group="symbol" id="DD08" label="😇" tooltip="Smiling face with halo"/>
+          <!-- U+1F607 -->
+          <key char="♀" group="symbol" id="DD09" label="♀" tooltip="Female sign"/>
+          <!-- U+2640 -->
+          <key char="☼" group="symbol" id="DD10" label="☼" tooltip="White sun with rays"/>
+          <!-- U+263C -->
+          <key group="bottomrow" id="BKSP"/>
+          <!-- row 3 -->
+          <key group="bottomrow" id="TAB"/>
+          <key char="☹" group="symbol" id="DC01" label="☹" tooltip="Frowning face"/>
+          <!-- U+2639 -->
+          <key char="😠" group="symbol" id="DC02" label="😠" tooltip="Angry face"/>
+          <!-- U+1F620 -->
+          <key char="😢" group="symbol" id="DC03" label="😢" tooltip="Crying face"/>
+          <!-- U+1F622 -->
+          <key char="😲" group="symbol" id="DC04" label="😲" tooltip="Astonished face"/>
+          <!-- U+1F632 -->
+          <key char="😖" group="symbol" id="DC05" label="😖" tooltip="Confounded face"/>
+          <!-- U+1F616 -->
+          <key char="😫" group="symbol" id="DC06" label="😫" tooltip="Tired face"/>
+          <!-- U+1F62B -->
+          <key char="😋" group="symbol" id="DC07" label="😋" tooltip="Face savouring delicious food"/>
+          <!-- U+1F60B -->
+          <key char="😈" group="symbol" id="DC08" label="😈" tooltip="Smiling face with horns"/>
+          <!-- U+1F608 -->
+          <key char="♂" group="symbol" id="DC09" label="♂" tooltip="Male sign"/>
+          <!-- U+2642 -->
+          <key char="☾" group="symbol" id="DC10" label="☾" tooltip="Last quarter moon"/>
+          <!-- U+263E -->
+          <key group="bottomrow" id="DELE"/>
+          <!-- row 2 -->
+          <key group="bottomrow" id="layer5"/>
+          <key char="♡" group="symbol" id="DB01" label="♡" tooltip="White heart suit"/>
+          <!-- U+2661 -->
+          <key char="♫" group="symbol" id="DB02" label="♫" tooltip="Beamed eighth note"/>
+          <!-- U+266B -->
+          <key char="☏" group="symbol" id="DB03" label="☏" tooltip="White telephone"/>
+          <!-- U+260F -->
+          <key char="✉" group="symbol" id="DB04" label="✉" tooltip="Envelope"/>
+          <!-- U+2709 -->
+          <key char="☂" group="symbol" id="DB05" label="☂" tooltip="Umbrella"/>
+          <!-- U+2602 -->
+          <key char="☮" group="symbol" id="DB06" label="☮" tooltip="Peace symbol"/>
+          <!-- U+262E -->
+          <key char="☆" group="symbol" id="DB07" label="☆" tooltip="White star"/>
+          <!-- U+2606 -->
+          <key char="☯" group="symbol" id="DB08" label="☯" tooltip="Yin yang"/>
+          <!-- U+262F -->
+          <key char="☢" group="symbol" id="DB09" label="☢" tooltip="Radioactive sign"/>
+          <!-- U+2622 -->
+          <key group="misc" id="RTRN" popup_id="RTRN_popup"/>
+        </panel>
+        <panel>
+          <panel>
+            <panel filename="Small-Alpha.svg" layer="alpha">
+              <!-- layer1 -->
+              <key group="bottomrow" id="LCTL"/>
+              <key group="bottomrow" id="LWIN"/>
+              <key group="bottomrow" id="LALT"/>
+            </panel>
+            <panel filename="Small-Numbers.svg" layer="numbers">
+              <key group="bottomrow" id="layer4"/>
+              <key group="bottomrow" id="layer3"/>
+              <key group="bottomrow" id="layer2"/>
+            </panel>
+            <panel filename="Small-Syms.svg" layer="syms">
+              <key group="bottomrow" id="layer4"/>
+              <key group="bottomrow" id="layer3"/>
+              <key group="bottomrow" id="layer2"/>
+            </panel>
+            <panel filename="Small-Fn.svg" layer="functionkeys">
+              <key group="bottomrow" id="layer4"/>
+              <key group="bottomrow" id="layer3"/>
+              <key group="bottomrow" id="layer2"/>
+            </panel>
+            <panel filename="Small-Snippets.svg" layer="snippets">
+              <key group="bottomrow" id="layer4"/>
+              <key group="bottomrow" id="layer3"/>
+              <key group="bottomrow" id="layer2"/>
+            </panel>
+            <panel filename="Small-Emoji.svg" layer="emoji">
+              <key group="bottomrow" id="layer4"/>
+              <key group="bottomrow" id="layer3"/>
+              <key group="bottomrow" id="layer2"/>
+            </panel>
+          </panel>
+          <panel filename="Small-Alpha.svg">
+            <key group="bottomrow" id="layer1"/>
+          </panel>
+          <panel>
+            <panel filename="Small-Alpha.svg" layer="alpha">
+              <key group="bottomrow" id="SPCE"/>
+              <key group="alphanumeric" id="LEFT"/>
+              <key group="alphanumeric" id="RGHT"/>
+              <key group="directions_alpha" id="UP"/>
+              <key group="directions_alpha" id="DOWN"/>
+            </panel>
+            <panel filename="Small-Numbers.svg" layer="numbers">
+              <key group="bottomrow" id="SPCE"/>
+              <key group="alphanumeric" id="LEFT"/>
+              <key group="alphanumeric" id="RGHT"/>
+              <key group="alphanumeric" id="UP"/>
+              <key group="alphanumeric" id="DOWN"/>
+            </panel>
+            <panel filename="Small-Syms.svg" layer="syms">
+              <key group="bottomrow" id="SPCE"/>
+              <key group="alphanumeric" id="LEFT"/>
+              <key group="alphanumeric" id="RGHT"/>
+              <key group="alphanumeric" id="UP"/>
+              <key group="alphanumeric" id="DOWN"/>
+            </panel>
+            <panel filename="Small-Emoji.svg" layer="emoji">
+              <key group="bottomrow" id="SPCE"/>
+              <key group="alphanumeric" id="LEFT"/>
+              <key group="alphanumeric" id="RGHT"/>
+              <key group="alphanumeric" id="UP"/>
+              <key group="alphanumeric" id="DOWN"/>
+            </panel>
+            <panel filename="Small-Fn.svg" layer="functionkeys">
+              <key group="bottomrow" id="SPCE"/>
+              <key group="alphanumeric" id="LEFT"/>
+              <key group="alphanumeric" id="RGHT"/>
+              <key group="alphanumeric" id="UP"/>
+              <key group="alphanumeric" id="DOWN"/>
+            </panel>
+            <panel filename="Small-Snippets.svg" layer="snippets">
+              <key group="bottomrow" id="quit"/>
+              <key group="bottomrow" id="settings"/>
+              <key group="click_control" id="hoverclick" unlatch_layer="false"/>
+            </panel>
+          </panel>
+        </panel>
+      </panel>
+      <!-- Panel with the click buttons -->
+      <panel filename="Small-Alpha.svg" id="click">
+        <key group="click" id="middleclick"/>
+        <key group="click" id="secondaryclick"/>
+        <key group="click" id="doubleclick"/>
+        <key group="click" id="dragclick"/>
+      </panel>
+    </box>
+  </box>
+  <!-- popup definition -->
+  <layout filename="Small-Alpha.svg" id="RTRN_popup">
+    <box compact="true">
+      <key id="settings"/>
+      <key id="move"/>
+      <key id="showclick"/>
+      <key group="nowordlist" id="hide" image="close.svg" svg_id="hide.popup"/>
+    </box>
+  </layout>
+</keyboard>
+


### PR DESCRIPTION
First of all, thank you very much for these layouts. Onboard with them is probably the best on-screen Korean keyboard on Linux!

So, I made additional ones based on those not included: Small, Phone, and Grid, by copying the corresponding lines from an existing Korean layout.

[Changelog](https://github.com/begin-theadventure/hamonikr-onboard-layout-ko/commits/changelog).
Previews:
Small
<img src="https://github.com/hamonikr/hamonikr-onboard-layout-ko/assets/99835765/5544eac0-76a0-4aea-aaee-a3d0330e114d" width="80%">
Phone
<img src="https://github.com/hamonikr/hamonikr-onboard-layout-ko/assets/99835765/90619a6b-223f-4b39-b191-b39ecb6c0e0b" width="80%">
Grid
<img src="https://github.com/hamonikr/hamonikr-onboard-layout-ko/assets/99835765/eca4320b-49c3-48b5-abe9-7a9d555bea10" width="80%">